### PR TITLE
Itinerary items create

### DIFF
--- a/app/controllers/api/v1/itineraries_controller.rb
+++ b/app/controllers/api/v1/itineraries_controller.rb
@@ -10,6 +10,16 @@ class Api::V1::ItinerariesController < ApplicationController
     params[:itinerary][:user_id] = params[:itinerary][:user_id].to_i
     itinerary = Itinerary.new(itinerary_params)
     if itinerary.save
+      if params[:itinerary][:items].each do | item_data |
+        item = Item.find_or_create_by(name: item_data[:name], address: item_data[:address]) do | new_item |
+          new_item.item_type = item_data[:item_type]
+          new_item.phone = item_data[:phone]
+          new_item.opening_hours = item_data[:opening_hours]
+
+        end
+        itinerary.items << item 
+      end
+    end
       render json: ItinerarySerializer.format_itinerary_list([itinerary]), status: :ok
     else
       render json: { errors: itinerary.errors.full_messages }, status: :unprocessable_entity
@@ -19,5 +29,9 @@ class Api::V1::ItinerariesController < ApplicationController
   private
   def itinerary_params
     params.require(:itinerary).permit(:city, :duration, :user_id)
+  end
+
+  def item_params(item_data)
+    item_data.permit(:name, :address, :item_type, :phone, opening_hours: [])
   end
 end

--- a/app/controllers/api/v1/itineraries_controller.rb
+++ b/app/controllers/api/v1/itineraries_controller.rb
@@ -9,8 +9,10 @@ class Api::V1::ItinerariesController < ApplicationController
   def create
     params[:itinerary][:user_id] = params[:itinerary][:user_id].to_i
     itinerary = Itinerary.new(itinerary_params)
+    # binding.pry
     if itinerary.save
-      if params[:itinerary][:items].each do | item_data |
+      if params[:itinerary][:items].present? 
+        params[:itinerary][:items].each do | item_data |
         item = Item.find_or_create_by(name: item_data[:name], address: item_data[:address]) do | new_item |
           new_item.item_type = item_data[:item_type]
           new_item.phone = item_data[:phone]

--- a/app/controllers/api/v1/itineraries_controller.rb
+++ b/app/controllers/api/v1/itineraries_controller.rb
@@ -9,7 +9,6 @@ class Api::V1::ItinerariesController < ApplicationController
   def create
     params[:itinerary][:user_id] = params[:itinerary][:user_id].to_i
     itinerary = Itinerary.new(itinerary_params)
-    # binding.pry
     if itinerary.save
       if params[:itinerary][:items].present? 
         params[:itinerary][:items].each do | item_data |

--- a/app/controllers/api/v1/itineraries_controller.rb
+++ b/app/controllers/api/v1/itineraries_controller.rb
@@ -7,7 +7,6 @@ class Api::V1::ItinerariesController < ApplicationController
   end
 
   def create
-    # binding.pry
     params[:itinerary][:user_id] = params[:itinerary][:user_id].to_i
     itinerary = Itinerary.new(itinerary_params)
     if itinerary.save

--- a/app/controllers/api/v1/itineraries_controller.rb
+++ b/app/controllers/api/v1/itineraries_controller.rb
@@ -4,6 +4,16 @@ class Api::V1::ItinerariesController < ApplicationController
   end
 
   def create
-    
+    binding.pry
+    itinerary = Itinerary.new(itinerary_params)
+    if itinerary.save
+      render json: ItinerarySerializer.format_itinerary_list([itinerary]), status: :ok
+    else
+    end
+  end
+
+  private
+  def itinerary_params
+    params.require(:itinerary).permit(:city, :duration, :user_id)
   end
 end

--- a/app/controllers/api/v1/itineraries_controller.rb
+++ b/app/controllers/api/v1/itineraries_controller.rb
@@ -2,4 +2,8 @@ class Api::V1::ItinerariesController < ApplicationController
   def index
     render json: ItinerarySerializer.format_itinerary_list(Itinerary.all), status: :ok
   end
+
+  def create
+    
+  end
 end

--- a/app/controllers/api/v1/itineraries_controller.rb
+++ b/app/controllers/api/v1/itineraries_controller.rb
@@ -1,14 +1,19 @@
 class Api::V1::ItinerariesController < ApplicationController
+  protect_from_forgery with: :null_session
+  skip_before_action :verify_authenticity_token
+
   def index
     render json: ItinerarySerializer.format_itinerary_list(Itinerary.all), status: :ok
   end
 
   def create
-    binding.pry
+    # binding.pry
+    params[:itinerary][:user_id] = params[:itinerary][:user_id].to_i
     itinerary = Itinerary.new(itinerary_params)
     if itinerary.save
       render json: ItinerarySerializer.format_itinerary_list([itinerary]), status: :ok
     else
+      render json: { errors: itinerary.errors.full_messages }, status: :unprocessable_entity
     end
   end
 

--- a/spec/requests/itineraries_request_spec.rb
+++ b/spec/requests/itineraries_request_spec.rb
@@ -48,14 +48,34 @@ RSpec.describe "Itineraries", type: :request do
           user_id: user_3.id,
            items: [
             {
+              item_type: "activity",
               name: "Tokyo Tower",
               address: "4 Chome-2-8 Shibakoen, Minato City, Tokyo, Japan",
-              item_type: "activity"
+              opening_hours: [
+                "Monday: 9:00 AM – 11:00 PM",
+                "Tuesday: 9:00 AM – 11:00 PM",
+                "Wednesday: 9:00 AM – 11:00 PM",
+                "Thursday: 9:00 AM – 11:00 PM",
+                "Friday: 9:00 AM – 11:00 PM",
+                "Saturday: 9:00 AM – 11:00 PM",
+                "Sunday: 9:00 AM – 11:00 PM"
+               ],
+              phone: "81 3-3433-5111"
             },
             {
+              item_type: "restaurant",
               name: "Men Kurai",
               address: "3 Chome-5-2 Sotokanda, Chiyoda City, Tokyo, Japan",
-              item_type: "restaurant"
+              opening_hours: [
+                "Monday: 11:00 AM – 2:30 PM, 5:00 PM – 8:30 PM",
+                "Tuesday: 11:00 AM – 2:30 PM, 5:00 PM – 8:30 PM",
+                "Wednesday: 11:00 AM – 2:30 PM, 5:00 PM – 8:30 PM",
+                "Thursday: 11:00 AM – 2:30 PM, 5:00 PM – 8:30 PM",
+                "Friday: 11:00 AM – 2:30 PM, 5:00 PM – 8:30 PM",
+                "Saturday: 11:00 AM – 2:30 PM, 5:00 PM – 8:30 PM",
+                "Sunday: Closed"
+               ],
+               phone: "123-456-7890"
             }
           ]
         } 
@@ -76,13 +96,17 @@ RSpec.describe "Itineraries", type: :request do
       itinerary = Itinerary.last
       expect(itinerary.items.count).to eq(2)
     
+      expect(itinerary.items.first.item_type).to eq("activity")
       expect(itinerary.items.first.name).to eq("Tokyo Tower")
       expect(itinerary.items.first.address).to eq("4 Chome-2-8 Shibakoen, Minato City, Tokyo, Japan")
-      expect(itinerary.items.first.item_type).to eq("activity")
-    
+      expect(itinerary.items.first.opening_hours).to include("Monday: 9:00 AM – 11:00 PM")
+      expect(itinerary.items.first.phone).to eq("81 3-3433-5111")
+
+      expect(itinerary.items.second.item_type).to eq("restaurant")
       expect(itinerary.items.second.name).to eq("Men Kurai")
       expect(itinerary.items.second.address).to eq("3 Chome-5-2 Sotokanda, Chiyoda City, Tokyo, Japan")
-      expect(itinerary.items.second.item_type).to eq("restaurant")
+      expect(itinerary.items.second.opening_hours).to include("Sunday: Closed")
+      expect(itinerary.items.second.phone).to eq("123-456-7890")
     end
   end
 end

--- a/spec/requests/itineraries_request_spec.rb
+++ b/spec/requests/itineraries_request_spec.rb
@@ -37,5 +37,52 @@ RSpec.describe "Itineraries", type: :request do
       expect(json[:data][0][:attributes][:duration]).to eq("full")
       expect(json[:data][0][:attributes][:user_id]).to eq(user_3.id)
     end
+
+    it "can create an itinerary with its associated items" do
+      user_3 = User.create!(name: "Joel")
+
+      itinerary_params = { 
+        itinerary: {
+          city: "Tokyo", 
+          duration: "half", 
+          user_id: user_3.id,
+           items: [
+            {
+              name: "Tokyo Tower",
+              address: "4 Chome-2-8 Shibakoen, Minato City, Tokyo, Japan",
+              item_type: "activity"
+            },
+            {
+              name: "Men Kurai",
+              address: "3 Chome-5-2 Sotokanda, Chiyoda City, Tokyo, Japan",
+              item_type: "restaurant"
+            }
+          ]
+        } 
+      }
+
+      post api_v1_itineraries_path, params: itinerary_params
+
+      expect(response).to be_successful
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(json[:data][0][:attributes][:city]).to eq("Tokyo")
+      expect(json[:data][0][:attributes][:duration]).to eq("half")
+      expect(json[:data][0][:attributes][:user_id]).to eq(user_3.id)
+
+      itinerary = Itinerary.last
+      expect(itinerary.items.count).to eq(2)
+
+      itinerary = Itinerary.last
+      expect(itinerary.items.count).to eq(2)
+    
+      expect(itinerary.items.first.name).to eq("Tokyo Tower")
+      expect(itinerary.items.first.address).to eq("4 Chome-2-8 Shibakoen, Minato City, Tokyo, Japan")
+      expect(itinerary.items.first.item_type).to eq("activity")
+    
+      expect(itinerary.items.second.name).to eq("Men Kurai")
+      expect(itinerary.items.second.address).to eq("3 Chome-5-2 Sotokanda, Chiyoda City, Tokyo, Japan")
+      expect(itinerary.items.second.item_type).to eq("restaurant")
+    end
   end
 end

--- a/spec/requests/itineraries_request_spec.rb
+++ b/spec/requests/itineraries_request_spec.rb
@@ -21,4 +21,21 @@ RSpec.describe "Itineraries", type: :request do
       expect(json[:data][0][:attributes]).to have_key(:user_id)
     end
   end
+  
+  describe "Create an Itinerary Endpoint" do
+    it "can create an itinerary" do
+      user_3 = User.create!(name: "Joel")
+
+      itinerary_params = { itinerary: {city: "Tokyo", duration: "full", user_id: user_3.id } }
+
+      post api_v1_itineraries_path, params: itinerary_params
+      
+      expect(response).to be_successful
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(json[:data][:attributes][:city]).to eq("Tokyo")
+      expect(json[:data][:attributes][:duration]).to eq("full")
+      expect(json[:data][:attributes][:user_id]).to eq(user_3.id)
+    end
+  end
 end

--- a/spec/requests/itineraries_request_spec.rb
+++ b/spec/requests/itineraries_request_spec.rb
@@ -92,9 +92,6 @@ RSpec.describe "Itineraries", type: :request do
 
       itinerary = Itinerary.last
       expect(itinerary.items.count).to eq(2)
-
-      itinerary = Itinerary.last
-      expect(itinerary.items.count).to eq(2)
     
       expect(itinerary.items.first.item_type).to eq("activity")
       expect(itinerary.items.first.name).to eq("Tokyo Tower")

--- a/spec/requests/itineraries_request_spec.rb
+++ b/spec/requests/itineraries_request_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe "Itineraries", type: :request do
       expect(response).to be_successful
       json = JSON.parse(response.body, symbolize_names: true)
 
-      expect(json[:data][:attributes][:city]).to eq("Tokyo")
-      expect(json[:data][:attributes][:duration]).to eq("full")
-      expect(json[:data][:attributes][:user_id]).to eq(user_3.id)
+      expect(json[:data][0][:attributes][:city]).to eq("Tokyo")
+      expect(json[:data][0][:attributes][:duration]).to eq("full")
+      expect(json[:data][0][:attributes][:user_id]).to eq(user_3.id)
     end
   end
 end


### PR DESCRIPTION
- Created tests for creating itineraries with associated items
- Initial happy path tests are passing
- Still need sad path and edge case tests for all of the itineraries request spec

- Added protect_from_forgery and skip_before_action to the itineraries controller to get past the CSRF token authentication
- Added some conditional logic to associate created items with the creation of an itinerary
- I feel this needs some refactoring still, but it is up and passing rspec.
- Postman returns a 200 for a post with items and a rails c I can see the items.
- Still need to create a show action to see the specific itinerary. 